### PR TITLE
Add margin to right of social icons

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 .git*
 docker-compose.yml
+node_modules

--- a/resources/views/partials/footer.blade.php
+++ b/resources/views/partials/footer.blade.php
@@ -8,7 +8,7 @@
           			</ul>
           		</div>
           			<div class="footer-menu w-1/2 text-right">
-		          		<div class="social-icons pin-r">
+		          		<div class="social-icons pin-r mr-8">
 		          			<a target="_blank" href="https://www.twitter.com/napyth">
 									      <svg xmlns="http://www.w3.org/2000/svg"
 													aria-label="Twitter" role="img"

--- a/script/build
+++ b/script/build
@@ -1,6 +1,8 @@
 #!/bin/zsh
 
 composer install --no-dev
+npm install
+npm run production
 
 docker build -t $DOCKER_IMAGE .
 

--- a/swarm.yml
+++ b/swarm.yml
@@ -14,12 +14,6 @@ services:
         delay: 5s
         max_attempts: 3
 
-  worker:
-    image: ${DOCKER_IMAGE:-napyouthbball_dev}
-    command: php artisan horizon
-    healthcheck:
-      disable: true
-
   redis:
     image: redis:4.0.10
     volumes:


### PR DESCRIPTION
This commit add a margin of size 8 to the right of the social icons.
This commit also builds the assets in the `script/build` in order to
minify the files. The worker service was also removed in this commit as
we don't use horizon at the moment.

[699490015461402](https://app.asana.com/0/0/699490015461402/f)