### PR TITLE
Set timezone in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,12 @@ STOPSIGNAL SIGKILL
 
 ENV WEB_DOCUMENT_ROOT=/app/public
 RUN apt-get update && \
-    apt-get install -y mysql-client-5.7 && \
+    apt-get install -y mysql-client-5.7 tzdata locales && \
     apt-get -q clean && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 && \
+ 		ln -sf /usr/share/zoneinfo/America/New_York /etc/localtime && \
+		dpkg-reconfigure --frontend noninteractive tzdata
 
 COPY --chown=application:application . /app
 WORKDIR /app


### PR DESCRIPTION
In order to properly serve the correct time in logs, this commit
installs the packages needed to change the timezone.