### PR TITLE
Fix the player policy to properly grab the team ids

### DIFF
--- a/app/Policies/PlayerPolicy.php
+++ b/app/Policies/PlayerPolicy.php
@@ -20,7 +20,7 @@ class PlayerPolicy
     public function view(User $user, Player $player)
     {
         if ($user->hasRole('coach')) {
-            return $user->team()->id == $player->team()->id;
+            return $user->team->id == $player->team->id;
         } else {
             return $user->hasRole('super_administrator');
         }


### PR DESCRIPTION
This commit uses the correct relationship methods for players and users
regarding their teams.