### PR TITLE
Fix Videos to show the correct type for coaches

### DIFF
--- a/app/Nova/Video.php
+++ b/app/Nova/Video.php
@@ -35,6 +35,15 @@ class Video extends Resource
         'id',
     ];
 
+    public static function indexQuery(NovaRequest $request, $query)
+    {
+        if($request->user()->hasRole('super_administrator')){
+            return $query;
+        } else {
+            return $query->where('type', 'Instructional');
+        }
+    }
+
     /**
      * Get the fields displayed by the resource.
      *
@@ -92,7 +101,7 @@ class Video extends Resource
     }
 
     /**
-     * Get the lenses available for the resource.
+     * Get the lenses available for the resource
      *
      * @param  \Illuminate\Http\Request  $request
      * @return array

--- a/app/Providers/NovaServiceProvider.php
+++ b/app/Providers/NovaServiceProvider.php
@@ -84,7 +84,6 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
             (new \Tightenco\NovaReleases\AllReleases)->canSee(function ($request) {
                 return $request->user()->hasRole('super_administrator');
             }),
-            new \vmitchell85\NovaLinks\Links(),
         ];
     }
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
         "silvanite/nova-field-cloudinary": "^1.0",
         "tightenco/nova-google-analytics": "^0.1.4",
         "tightenco/nova-releases": "^0.2.2",
-        "vmitchell85/nova-links": "^0.0.1",
         "vyuldashev/nova-permission": "^1.3"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "160fc86b6e834e2d07a4538f85e16cbf",
+    "content-hash": "031eb6b9375e537c67a409470dfa62c5",
     "packages": [
         {
             "name": "cakephp/chronos",
@@ -4235,60 +4235,6 @@
                 "environment"
             ],
             "time": "2018-07-29T20:33:41+00:00"
-        },
-        {
-            "name": "vmitchell85/nova-links",
-            "version": "v0.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/vmitchell85/nova-links.git",
-                "reference": "420fb04bd036ba312c328f1dfb2a34f09b63743f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/vmitchell85/nova-links/zipball/420fb04bd036ba312c328f1dfb2a34f09b63743f",
-                "reference": "420fb04bd036ba312c328f1dfb2a34f09b63743f",
-                "shasum": ""
-            },
-            "require": {
-                "laravel/nova": "*",
-                "php": ">=7.1.0"
-            },
-            "require-dev": {
-                "orchestra/testbench": "^3.6",
-                "phpunit/phpunit": "7.1"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "providers": [
-                        "vmitchell85\\NovaLinks\\NovaLinksServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "vmitchell85\\NovaLinks\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Vince Mitchell",
-                    "email": "vincent.mitchell@gmail.com",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Add custom links to your nova navigation",
-            "homepage": "https://github.com/vmitchell85/nova-links",
-            "keywords": [
-                "laravel",
-                "nova"
-            ],
-            "time": "2018-08-25T20:06:40+00:00"
         },
         {
             "name": "vyuldashev/nova-permission",

--- a/config/nova-links.php
+++ b/config/nova-links.php
@@ -1,7 +1,0 @@
-<?php
-
-return [
-    'links' => [
-        'Coaches Videos' => '/admin/resources/videos/lens/instructional-videos'
-    ]
-];


### PR DESCRIPTION
In order to properly display instructional videos for coaches, this
commit adds the `indexQuery` to the Nova Video resource.