### PR TITLE
Add schedules to site and allow coaches to update practices

### DIFF
--- a/app/Http/Controllers/SchedulesController.php
+++ b/app/Http/Controllers/SchedulesController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Game;
+use App\Practice;
+use Illuminate\Http\Request;
+
+class SchedulesController extends Controller
+{
+    public function index()
+    {
+    	$practices = Practice::notOld()->whereNotNull('team_id')->get();
+    	$games = Game::all();
+
+    	return view('schedules.index', ['practices'=>$practices,'games'=>$games]);
+    }
+}

--- a/app/Nova/Practice.php
+++ b/app/Nova/Practice.php
@@ -3,6 +3,7 @@
 namespace App\Nova;
 
 use App\Nova\Lenses\OpenPracticeTimes;
+use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Fields\DateTime;
@@ -33,6 +34,15 @@ class Practice extends Resource
     public static $search = [
         'practice_time'
     ];
+
+    public static function indexQuery(NovaRequest $request, $query)
+    {
+        if($request->user()->hasRole('super_administrator')){
+            return $query;
+        } else {
+            return $query->where('practice_time', '>', Carbon::now());
+        }
+    }
 
     /**
      * Get the fields displayed by the resource.

--- a/app/Policies/GamePolicy.php
+++ b/app/Policies/GamePolicy.php
@@ -10,10 +10,6 @@ class GamePolicy
 {
     use HandlesAuthorization;
 
-    public function viewAny(User $user)
-    {
-        return $user->hasRole('super_administrator');
-    }
     /**
      * Determine whether the user can view the game.
      *
@@ -23,7 +19,7 @@ class GamePolicy
      */
     public function view(User $user, Game $game)
     {
-        return $user->hasRole('super_administrator');
+        return true;
     }
 
     /**

--- a/app/Policies/TeamPolicy.php
+++ b/app/Policies/TeamPolicy.php
@@ -10,10 +10,15 @@ class TeamPolicy
 {
     use HandlesAuthorization;
 
-    public function viewAny(User $user)
-    {
-        return $user->hasRole('super_administrator');
-    }
+    // public function viewAny(User $user)
+    // {
+    //     if ($user->hasRole('coach')) {
+    //         $team = Team::find($user->team->id);
+    //         return $user->team->id === $team->id;
+    //     } else {
+    //         return $user->hasRole('super_administrator');
+    //     }
+    // }
     
     /**
      * Determine whether the user can view the team.
@@ -24,7 +29,7 @@ class TeamPolicy
      */
     public function view(User $user, Team $team)
     {
-        return $user->hasRole('super_administrator');
+        return true;
     }
 
     /**

--- a/app/Practice.php
+++ b/app/Practice.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 
 class Practice extends Model
@@ -20,6 +21,11 @@ class Practice extends Model
   public function getFormattedPracticeTimeAttribute()
   {
   	return $this->practice_time->format('g:ia');
+  }
+
+  public function scopeNotOld($query)
+  {
+      return $query->where('practice_time', '>', Carbon::now());
   }
 
 	public function team()

--- a/resources/views/partials/footer.blade.php
+++ b/resources/views/partials/footer.blade.php
@@ -2,8 +2,9 @@
           	<div class="container mx-auto items-center flex">
           		<div class="footer-menu w-1/2 text-left ml-4">
           			<ul class="list-reset sm:flex text-lg flex-col text-left">
-          				<!-- <li><a href="/teams" class="text-navy-darker no-underline hover:text-white">Teams</a></li>
-          				<li><a href="/teams" class="text-navy-darker no-underline hover:text-white">Photos & Videos</a></li> -->
+          				<li><a href="/schedules" class="text-navy-darker no-underline hover:text-white">Schedules</a></li>
+          				<li><a href="/teams" class="text-navy-darker no-underline hover:text-white">Teams</a></li>
+          				<!-- <li><a href="/teams" class="text-navy-darker no-underline hover:text-white">Photos & Videos</a></li> -->
           				<li><a href="/forms" class="text-navy-darker no-underline hover:text-white">Forms</a></li>
           			</ul>
           		</div>

--- a/resources/views/partials/navbar.blade.php
+++ b/resources/views/partials/navbar.blade.php
@@ -7,7 +7,9 @@
 					  	</div>
 					  	<div :class="open ? 'block' : 'hidden'" class="w-full sm:items-center sm:w-auto sm:hidden md:block">
 					  			<ul class="list-reset md:flex sm:flex-grow pin-r">
-					    
+					    			<li><a href="/schedules" class="font-sans block sm:inline-block sm:mt-0 mt-4 lg:inline-block lg:mt-0 text-navy-lighter no-underline hover:text-white mr-4">
+						        Schedules
+						      	</a></li>
 						      	<li><a href="/teams" class="font-sans block sm:inline-block sm:mt-0 mt-4 lg:inline-block lg:mt-0 text-navy-lighter no-underline hover:text-white mr-4">
 						        Teams
 						      	</a></li>

--- a/resources/views/schedules/index.blade.php
+++ b/resources/views/schedules/index.blade.php
@@ -1,0 +1,50 @@
+@extends('layouts.master')
+
+@section('content')
+			<h1>Schedules</h1>
+			<div class="w-full mt-8">
+	    	<h2>Practices</h2>
+	    	<table class="w-full text-left table-collapse mt-4">
+					<thead>
+						<tr>
+							<th class="text-lg font-semibold text-navy-darker p-2 bg-navy-lighter">Date</th>
+							<th class="text-lg font-semibold text-navy-darker p-2 bg-navy-lighter">Location</th>
+							<th class="text-lg font-semibold text-navy-darker p-2 bg-navy-lighter">Team</th>
+						</tr>
+					</thead>
+					<tbody>
+				@foreach($practices as $practice)
+					<tr>
+						<td class="p-2 border-b border-grey-light">{{$practice->formatted_practice_date}} @ {{$practice->formatted_practice_time}}</td>
+						<td class="p-2 border-b border-grey-light">{{$practice->location->first()->building}} - {{$practice->location->first()->building}}</td>
+						<td class="p-2 border-b border-grey-light">{{$practice->team->first()->name}}</td>
+					</tr>
+				@endforeach
+					</tbody>
+				</table>
+			</div>
+
+			<div class="w-full mt-8">
+			<h2>Games</h2>
+			<table class="w-full text-left table-collapse mt-4">
+				<thead>
+					<tr>
+						<th class="text-lg font-semibold text-navy-darker p-2 bg-navy-lighter">Date</th>
+						<th class="text-lg font-semibold text-navy-darker p-2 bg-navy-lighter">Time</th>
+						<th class="text-lg font-semibold text-navy-darker p-2 bg-navy-lighter">Home</th>
+						<th class="text-lg font-semibold text-navy-darker p-2 bg-navy-lighter">Away</th>
+					</tr>
+				</thead>
+				<tbody>
+			@foreach($games as $game)
+				<tr>
+					<td class="p-2 border-b border-grey-light">{{$game->formatted_game_date}}</td>
+					<td class="p-2 border-b border-grey-light">{{$game->formatted_game_time}}</td>
+					<td class="p-2 border-b border-grey-light"><a href="/teams/{{$game->teams->first()->id}}" class="text-navy no-underline hover:text-navy-light">{{$game->teams->first()->name}}</a></td>
+					<td class="p-2 border-b border-grey-light"><a href="/teams/{{$game->teams->last()->id}}" class="text-navy no-underline hover:text-navy-light">{{$game->teams->last()->name}}</a></td>
+				</tr>
+			@endforeach
+				</tbody>
+			</table>
+			</div>
+@endsection

--- a/resources/views/teams/index.blade.php
+++ b/resources/views/teams/index.blade.php
@@ -4,7 +4,7 @@
     	<h1>Leagues</h1>
     	<div class="flex flex-col mx-auto md:flex-row mt-2 w-full">
 			@foreach($leagues as $league)
-				<div class="mx-4 my-4 rounded shadow-lg w-1/2">
+				<div class="mx-4 my-4 rounded shadow-lg w-full">
 					<div class="items-center flex flex-row bg-navy px-4 py-4 text-white">
 						<h2>{{$league->name}}</h2>
 					</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,8 @@ Route::get('/forms', function () {
     return view('forms');
 });
 
+Route::get('/schedules', 'SchedulesController@index');
+
 Route::get('/teams', 'TeamsController@index');
 Route::get('/teams/{team}', 'TeamsController@show');
 


### PR DESCRIPTION
In order for parents to see practice schedules and all games this
commit adds the `/schedules` route.  This commit also updates the
coaches role for users to allow them to see games and teams so they can
sign up for practices.

[916811454945522](https://app.asana.com/0/0/916811454945522/f)