### PR TITLE
Order events on schedules page and add practices to team pages

### DIFF
--- a/app/Http/Controllers/SchedulesController.php
+++ b/app/Http/Controllers/SchedulesController.php
@@ -10,8 +10,8 @@ class SchedulesController extends Controller
 {
     public function index()
     {
-    	$practices = Practice::notOld()->whereNotNull('team_id')->get();
-    	$games = Game::all();
+    	$practices = Practice::notOld()->whereNotNull('team_id')->orderBy('practice_time', 'asc')->get();
+    	$games = Game::all()->sortBy('game_time');
 
     	return view('schedules.index', ['practices'=>$practices,'games'=>$games]);
     }

--- a/resources/views/teams/show.blade.php
+++ b/resources/views/teams/show.blade.php
@@ -45,4 +45,23 @@
 				</tbody>
 			</table>
 		</div>
+		<div class="w-full mt-8">
+			<h3>Practices <span class="text-xs text-grey-dark">*Practices are subject to change*</span></h3>
+	    	<table class="w-full text-left table-collapse mt-4">
+					<thead>
+						<tr>
+							<th class="text-lg font-semibold text-navy-darker p-2 bg-navy-lighter">Date</th>
+							<th class="text-lg font-semibold text-navy-darker p-2 bg-navy-lighter">Location</th>
+						</tr>
+					</thead>
+					<tbody>
+				@foreach($team->practices as $practice)
+					<tr>
+						<td class="p-2 border-b border-grey-light">{{$practice->formatted_practice_date}} @ {{$practice->formatted_practice_time}}</td>
+						<td class="p-2 border-b border-grey-light">{{$practice->location->building}} - {{$practice->location->court}}</td>
+					</tr>
+				@endforeach
+					</tbody>
+				</table>
+		</div>
 @endsection


### PR DESCRIPTION
In order to make it easier to read this commit orders the games and
practices on the schedules page.  This commit also adds the practice
schedule to the teams pages.