### PR TITLE
 Sort teams page by standings inside each league

### DIFF
--- a/app/League.php
+++ b/app/League.php
@@ -19,4 +19,11 @@ class League extends Model
     {
         return $this->belongsTo('App\Season');
     }
+
+    public function standings()
+    {
+        return $this->teams->sortByDesc( function ($team){
+            return  $team->wins;
+        });
+    }
 }

--- a/app/Team.php
+++ b/app/Team.php
@@ -18,7 +18,9 @@ class Team extends Model
 
     public function record()
     {
-        return $this->wins->count() . "-". $this->losses();
+        $wins = $this->wins->count() ? $this->wins->count() : 0;
+        $losses = $this->losses() != -1 ? $this->losses() : 0;
+        return $wins . "-". $losses;
     }
 
     public function losses()

--- a/resources/views/teams/index.blade.php
+++ b/resources/views/teams/index.blade.php
@@ -10,7 +10,7 @@
 					</div>
 					<div>
 						<ul class="list-reset">
-						@foreach($league->teams as $team)
+						@foreach($league->standings() as $team)
 							<li class="ml-5 p-3"> <a href="/teams/{{$team->id}}" class="text-navy-darker no-underline hover:text-navy-light">{{$team->name}}</a> <span class="font-bold italic">{{$team->record() }}</span></li>
 						@endforeach
 						</ul>


### PR DESCRIPTION
In order to display the league teams by their standings, this commit
adds the proper standings method to the `League` model and updates the
blade resource.